### PR TITLE
fixed createAccount Instructions

### DIFF
--- a/src/Kamino.ts
+++ b/src/Kamino.ts
@@ -2689,7 +2689,6 @@ export class Kamino {
           tokenAAta,
           owner,
           strategyState.strategy.tokenAMint,
-          tokenAData!.owner
         )
       );
     }
@@ -2700,7 +2699,6 @@ export class Kamino {
           tokenBAta,
           owner,
           strategyState.strategy.tokenBMint,
-          tokenBData!.owner
         )
       );
     }


### PR DESCRIPTION
## Fixed undefined parameters in `getCreateAssociatedTokenAccountInstructionsIfNotExist()`

### Issue Description
The function `getCreateAssociatedTokenAccountInstructionsIfNotExist()` was passing `undefined` parameters when `tokenAData` and `tokenBData` were null. This caused potential issues during token account creation, as the undefined parameters could lead to incorrect behavior.

### Impact
This fix ensures that Associated Account is created when pair includes SOL token

