### PR TITLE
fix Meteora encoding bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "bn.js": "^5.2.1",
     "bs58": "^6.0.0",
     "buffer-layout": "^1.2.2",
-    "decimal.js": "^10.3.1"
+    "decimal.js": "^10.3.1",
+    "fzstd": "^0.1.1"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.5",

--- a/src/services/MeteoraService.ts
+++ b/src/services/MeteoraService.ts
@@ -47,13 +47,13 @@ export class MeteoraService {
       .getProgramAccounts(METEORA_PROGRAM_ID, {
         commitment: 'confirmed',
         filters: [{ dataSize: 904n }],
+        encoding: 'base64',
       })
       .send();
     const pools: MeteoraPool[] = [];
     for (let i = 0; i < rawPools.length; i++) {
       try {
-        const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data));
-        //const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data[0], 'base64'));
+        const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data[0], 'base64'));
         pools.push({ pool: lbPair, key: rawPools[i].pubkey });
       } catch (e) {
         console.log(e);

--- a/src/services/MeteoraService.ts
+++ b/src/services/MeteoraService.ts
@@ -15,6 +15,8 @@ import { WhirlpoolAprApy } from './WhirlpoolAprApy';
 import { PROGRAM_ID as METEORA_PROGRAM_ID } from '../@codegen/meteora/programId';
 import { getPriceOfBinByBinIdWithDecimals } from '../utils/meteora';
 import { DEFAULT_PUBLIC_KEY } from '../constants/pubkeys';
+import { decompress } from 'fzstd';
+
 
 export interface MeteoraPool {
   key: Address;
@@ -47,13 +49,16 @@ export class MeteoraService {
       .getProgramAccounts(METEORA_PROGRAM_ID, {
         commitment: 'confirmed',
         filters: [{ dataSize: 904n }],
-        encoding: 'base64',
+        encoding: 'base64+zstd',
       })
       .send();
     const pools: MeteoraPool[] = [];
     for (let i = 0; i < rawPools.length; i++) {
       try {
-        const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data[0], 'base64'));
+        const compressedData = Buffer.from(rawPools[i].account.data[0], 'base64');
+        const decompressedData = decompress(compressedData);
+
+        const lbPair = LbPair.decode(Buffer.from(decompressedData));
         pools.push({ pool: lbPair, key: rawPools[i].pubkey });
       } catch (e) {
         console.log(e);

--- a/src/services/MeteoraService.ts
+++ b/src/services/MeteoraService.ts
@@ -53,6 +53,7 @@ export class MeteoraService {
     for (let i = 0; i < rawPools.length; i++) {
       try {
         const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data));
+        //const lbPair = LbPair.decode(Buffer.from(rawPools[i].account.data[0], 'base64'));
         pools.push({ pool: lbPair, key: rawPools[i].pubkey });
       } catch (e) {
         console.log(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,6 +2402,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fzstd@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/fzstd/-/fzstd-0.1.1.tgz#a3da29f2fff45070ca90073f866d97e0c56a4a52"
+  integrity sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
this PR is attempting to fix the error I'm getting in historian when calling the getMeteoraPools() method:
```
error: Error occurred during historical snapshot {"cluster":"mainnet-beta","error":"SolanaError: JSON-RPC error: Invalid method parameter(s) (binary/base58 encoding not supported)","operation":"meteoraPools","service":"hubble-historian","session":"38d03934-1453-4520-83a0-b75564f85e03","timestamp":"2025-06-30 16:13:21"}

```
### Checklist

- [] If I'm working with the latest kliquidity.so version, I have modified the so with the latest one from master
