### PR TITLE
Paralelise getUserPositions RPC requests

### DIFF
--- a/src/Kamino.ts
+++ b/src/Kamino.ts
@@ -7061,8 +7061,10 @@ export class Kamino {
     wallet: Address,
     strategyFilters: StrategiesFilters = { strategyCreationStatus: 'LIVE' }
   ): Promise<KaminoPosition[]> => {
-    const userTokenAccounts = await this.getAllTokenAccounts(wallet);
-    const liveStrategies = await this.getAllStrategiesWithFilters(strategyFilters);
+    const [userTokenAccounts, liveStrategies] = await Promise.all([
+      this.getAllTokenAccounts(wallet),
+      this.getAllStrategiesWithFilters(strategyFilters),
+    ]);
     const positions: KaminoPosition[] = [];
     for (const tokenAccount of userTokenAccounts) {
       const accountData = tokenAccount.account.data;


### PR DESCRIPTION
There's no reason to wait for two RPC replies in sequence when there is no dependency between them. This reduces the runtime for this method to a single network round trip, instead of two.

In practice instead of 66ms we are down to 33ms, so 2x improvement.

### Checklist

- [] If I'm working with the latest kliquidity.so version, I have modified the so with the latest one from master
